### PR TITLE
feat[brokerosb]: add getstatus REF: #20

### DIFF
--- a/client.go
+++ b/client.go
@@ -52,6 +52,7 @@ const (
 	lastOperationURLFmt        = "%s/v2/service_instances/%s/last_operation"
 	bindingLastOperationURLFmt = "%s/v2/service_instances/%s/service_bindings/%s/last_operation"
 	bindingURLFmt              = "%s/v2/service_instances/%s/service_bindings/%s"
+	statusURL                  = "%s/status"
 )
 
 // NewClient is a CreateFunc for creating a new functional Client and

--- a/get_status.go
+++ b/get_status.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v2
+
+import (
+	"fmt"
+	"net/http"
+)
+
+func (c *client) GetStatus() (*GetStatusResponse, error) {
+	fullURL := fmt.Sprintf(statusURL, c.URL)
+
+	response, err := c.prepareAndDo(http.MethodGet, fullURL, nil /* params */, nil /* request body */, nil /* originating identity */)
+	if err != nil {
+		return nil, err
+	}
+
+	defer func() {
+		_ = drainReader(response.Body)
+		response.Body.Close()
+	}()
+
+	switch response.StatusCode {
+	case http.StatusOK:
+		statusResponse := &GetStatusResponse{}
+		if err := c.unmarshalResponse(response, statusResponse); err != nil {
+			return nil, HTTPStatusCodeError{StatusCode: response.StatusCode, ResponseError: err}
+		}
+
+		return statusResponse, nil
+	default:
+		return nil, c.handleFailureResponse(response)
+	}
+}

--- a/interface.go
+++ b/interface.go
@@ -206,6 +206,7 @@ type Client interface {
 	// RotateBinding calls PUT on the Broker's binding endpoint
 	// (/v2/service_instances/instance-id/service_bindings/binding-id).
 	RotateBinding(r *RotateBindingRequest) (*BindResponse, error)
+	GetStatus() (*GetStatusResponse, error)
 }
 
 // CreateFunc allows control over which implementation of a Client is

--- a/types.go
+++ b/types.go
@@ -697,3 +697,9 @@ type RotateBindingRequest struct {
 	// this request.
 	OriginatingIdentity *OriginatingIdentity `json:"originatingIdentity,omitempty"`
 }
+
+type GetStatusRequest struct{}
+
+type GetStatusResponse struct {
+	Status string `json:"status"`
+}


### PR DESCRIPTION
This PR introduces the getStatus function to retrieve the current status of the OSB broker.