### PR TITLE
Add unified OSB async response interface

### DIFF
--- a/provision_instance_methods.go
+++ b/provision_instance_methods.go
@@ -1,0 +1,16 @@
+package v2
+
+// IsAsync returns true if the provision request is being handled asynchronously.
+func (r *ProvisionResponse) IsAsync() bool {
+	return r.Async
+}
+
+// GetOperationKey returns the operation key for the asynchronous provision request.
+func (r *ProvisionResponse) GetOperationKey() *OperationKey {
+	return r.OperationKey
+}
+
+// GetDashboardURL returns the dashboard URL provided by the broker if available.
+func (r *ProvisionResponse) GetDashboardURL() *string {
+	return r.DashboardURL
+}

--- a/types.go
+++ b/types.go
@@ -703,3 +703,15 @@ type GetStatusRequest struct{}
 type GetStatusResponse struct {
 	Status string `json:"status"`
 }
+
+// OSBAsyncResponse defines the common behavior for asynchronous responses
+// from the Open Service Broker API. Any OSB response type that may be
+// handled asynchronously should implement this interface.
+type OSBAsyncResponse interface {
+	// IsAsync returns true if the broker is handling the request asynchronously.
+	IsAsync() bool
+	// GetOperationKey returns the broker-supplied identifier for the asynchronous operation.
+	GetOperationKey() *OperationKey
+	// GetDashboardURL returns the dashboard URL if available.
+	GetDashboardURL() *string
+}

--- a/update_instance_methods.go
+++ b/update_instance_methods.go
@@ -1,0 +1,16 @@
+package v2
+
+// IsAsync returns true if the update request is being handled asynchronously.
+func (r *UpdateInstanceResponse) IsAsync() bool {
+	return r.Async
+}
+
+// GetOperationKey returns the operation key of the asynchronous request.
+func (r *UpdateInstanceResponse) GetOperationKey() *OperationKey {
+	return r.OperationKey
+}
+
+// GetDashboardURL returns the dashboard URL if provided by the broker.
+func (r *UpdateInstanceResponse) GetDashboardURL() *string {
+	return r.DashboardURL
+}


### PR DESCRIPTION
Introduce a new `v2` package to unify asynchronous response handling for OSB operations.

### Changes:
- `ProvisionResponse` and `UpdateInstanceResponse` now implement `OSBAsyncResponse`
- Added `IsAsync()`, `GetOperationKey()`, `GetDashboardURL()` methods
- Defined `OSBAsyncResponse` interface for all async OSB responses

This refactor improves readability, maintainability, and prepares the codebase for v2 migration.