### PR TITLE
Add deleting state to LastOperationState

### DIFF
--- a/types.go
+++ b/types.go
@@ -474,6 +474,7 @@ const (
 	StateInProgress LastOperationState = "in progress"
 	StateSucceeded  LastOperationState = "succeeded"
 	StateFailed     LastOperationState = "failed"
+	StateDeleting   LastOperationState = "deleting"
 )
 
 type BindingMetadata struct {


### PR DESCRIPTION
### **Description:**

This PR introduces a new state `StateDeleting` to the `LastOperationState` enum to represent asynchronous deletion operations.

### **Changes:**

* Added `StateDeleting LastOperationState = "deleting"` to the enum.

