### PR TITLE
Implement `IsNotEmpty` for `BindResource` REF: #26

### DIFF
--- a/bind_resource_methods.go
+++ b/bind_resource_methods.go
@@ -1,0 +1,6 @@
+package v2
+
+// IsNotEmpty returns true if either AppGUID or Route in the BindResource is not empty.
+func (br *BindResource) IsNotEmpty() bool {
+	return (br.AppGUID != nil && *br.AppGUID != "") || (br.Route != nil && *br.Route != "")
+}


### PR DESCRIPTION
#### **Description**

This PR introduces a utility method `IsNotEmpty()` for the `BindResource` struct. The method checks if **either** `AppGUID` or `Route` is non-empty and returns `true` in that case, otherwise it returns `false`.

This simplifies validation logic by providing a single, reusable check for non-empty `BindResource` instances.

#### **Changes**

* Added `IsNotEmpty()` method to `BindResource`
